### PR TITLE
Add asset origin metadata support

### DIFF
--- a/app/app/components/asset-origin-form.tsx
+++ b/app/app/components/asset-origin-form.tsx
@@ -1,0 +1,288 @@
+import type { AssetOrigin } from "~/types/nft";
+import type { AssetOriginTemplateId } from "~/constants/assetOrigin";
+import { ASSET_ORIGIN_TEMPLATE_LABELS } from "~/constants/assetOrigin";
+
+interface AssetOriginFormProps {
+    value: AssetOrigin;
+    onChange: (next: AssetOrigin) => void;
+    templateId: AssetOriginTemplateId;
+    onTemplateChange: (next: AssetOriginTemplateId) => void;
+}
+
+export default function AssetOriginForm({ value, onChange, templateId, onTemplateChange }: AssetOriginFormProps) {
+    return (
+        <div className="w-full max-w-3xl bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 space-y-6">
+            <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                    Asset origin template
+                </label>
+                <select
+                    value={templateId}
+                    onChange={(e) => onTemplateChange(e.target.value as AssetOriginTemplateId)}
+                    className="w-full bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-gray-100"
+                >
+                    {Object.entries(ASSET_ORIGIN_TEMPLATE_LABELS).map(([key, label]) => (
+                        <option key={key} value={key}>
+                            {label}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField label="Title" value={value.title ?? ""} onChange={(title) => onChange({ ...value, title })} />
+                <InputField label="Asset type *" value={value.asset_type} onChange={(asset_type) => onChange({ ...value, asset_type })} required />
+            </section>
+
+            <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    label="Author name *"
+                    value={value.author.name}
+                    onChange={(name) => onChange({ ...value, author: { ...value.author, name } })}
+                    required
+                />
+                <InputField
+                    label="Author copyright"
+                    value={value.author.copyright ?? ""}
+                    onChange={(copyright) => onChange({ ...value, author: { ...value.author, copyright } })}
+                />
+            </section>
+
+            <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <InputField
+                    label="Source name"
+                    value={value.source?.name ?? ""}
+                    onChange={(name) =>
+                        onChange({ ...value, source: { ...(value.source ?? {}), name } })
+                    }
+                />
+                <InputField
+                    label="Source URL"
+                    value={value.source?.url ?? ""}
+                    onChange={(url) =>
+                        onChange({ ...value, source: { ...(value.source ?? {}), url } })
+                    }
+                />
+                <InputField
+                    label="Original release date"
+                    placeholder="YYYY-MM-DD"
+                    value={value.source?.original_release_date ?? ""}
+                    onChange={(original_release_date) =>
+                        onChange({
+                            ...value,
+                            source: { ...(value.source ?? {}), original_release_date },
+                        })
+                    }
+                />
+            </section>
+
+            <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <InputField
+                    label="License type *"
+                    value={value.license.type}
+                    onChange={(type) => onChange({ ...value, license: { ...value.license, type } })}
+                    required
+                />
+                <InputField
+                    label="License name *"
+                    value={value.license.name}
+                    onChange={(name) => onChange({ ...value, license: { ...value.license, name } })}
+                    required
+                />
+                <InputField
+                    label="License URL *"
+                    value={value.license.url}
+                    onChange={(url) => onChange({ ...value, license: { ...value.license, url } })}
+                    required
+                />
+            </section>
+
+            <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <CheckboxField
+                    label="Asset was modified"
+                    checked={value.modifications?.is_modified ?? false}
+                    onChange={(is_modified) =>
+                        onChange({
+                            ...value,
+                            modifications: {
+                                ...(value.modifications ?? { modified_by: "" }),
+                                is_modified,
+                            },
+                        })
+                    }
+                />
+                <InputField
+                    label="Modified by"
+                    value={value.modifications?.modified_by ?? ""}
+                    onChange={(modified_by) =>
+                        onChange({
+                            ...value,
+                            modifications: {
+                                ...(value.modifications ?? { is_modified: false }),
+                                modified_by,
+                            },
+                        })
+                    }
+                />
+                <InputField
+                    label="Modification notes"
+                    value={value.modifications?.notes ?? ""}
+                    onChange={(notes) =>
+                        onChange({
+                            ...value,
+                            modifications: {
+                                ...(value.modifications ?? { is_modified: false }),
+                                notes,
+                            },
+                        })
+                    }
+                />
+            </section>
+
+            <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    label="Mint fee type"
+                    value={value.commercial_terms.mint_fee_type ?? ""}
+                    onChange={(mint_fee_type) =>
+                        onChange({
+                            ...value,
+                            commercial_terms: {
+                                ...value.commercial_terms,
+                                mint_fee_type,
+                            },
+                        })
+                    }
+                />
+                <InputField
+                    label="Mint fee note"
+                    value={value.commercial_terms.mint_fee_note ?? ""}
+                    onChange={(mint_fee_note) =>
+                        onChange({
+                            ...value,
+                            commercial_terms: {
+                                ...value.commercial_terms,
+                                mint_fee_note,
+                            },
+                        })
+                    }
+                />
+                <CheckboxField
+                    label="Exclusive rights transferred"
+                    checked={value.commercial_terms.exclusive_rights_transferred}
+                    onChange={(exclusive_rights_transferred) =>
+                        onChange({
+                            ...value,
+                            commercial_terms: {
+                                ...value.commercial_terms,
+                                exclusive_rights_transferred,
+                            },
+                        })
+                    }
+                />
+            </section>
+
+            <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <InputField
+                    label="Provenance: minted by"
+                    value={value.provenance?.minted_by ?? ""}
+                    onChange={(minted_by) =>
+                        onChange({
+                            ...value,
+                            provenance: { ...(value.provenance ?? {}), minted_by },
+                        })
+                    }
+                />
+                <InputField
+                    label="Provenance: mint context"
+                    value={value.provenance?.mint_context ?? ""}
+                    onChange={(mint_context) =>
+                        onChange({
+                            ...value,
+                            provenance: { ...(value.provenance ?? {}), mint_context },
+                        })
+                    }
+                />
+            </section>
+        </div>
+    );
+}
+
+interface InputFieldProps {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    required?: boolean;
+    placeholder?: string;
+}
+
+function InputField({ label, value, onChange, required, placeholder }: InputFieldProps) {
+    return (
+        <label className="block text-sm text-gray-700 dark:text-gray-200">
+            <span className="font-medium">
+                {label} {required && <span className="text-red-500">*</span>}
+            </span>
+            <input
+                type="text"
+                value={value}
+                placeholder={placeholder}
+                onChange={(e) => onChange(e.target.value)}
+                className="mt-1 w-full bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-gray-900 dark:text-gray-100"
+            />
+        </label>
+    );
+}
+
+interface CheckboxFieldProps {
+    label: string;
+    checked: boolean;
+    onChange: (value: boolean) => void;
+}
+
+function CheckboxField({ label, checked, onChange }: CheckboxFieldProps) {
+    return (
+        <label className="inline-flex items-center space-x-2 text-sm text-gray-700 dark:text-gray-200">
+            <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e) => onChange(e.target.checked)}
+                className="h-4 w-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
+            />
+            <span>{label}</span>
+        </label>
+    );
+}
+
+interface AssetOriginSummaryProps {
+    assetOrigin: AssetOrigin;
+}
+
+export function AssetOriginSummary({ assetOrigin }: AssetOriginSummaryProps) {
+    const exclusive = assetOrigin.commercial_terms.exclusive_rights_transferred;
+    const isModified = assetOrigin.modifications?.is_modified ?? false;
+    return (
+        <div className="w-full max-w-3xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 space-y-3 text-sm text-gray-700 dark:text-gray-200">
+            <h3 className="text-base font-semibold">License & provenance</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <SummaryItem label="Author" value={assetOrigin.author.name || "—"} />
+                <SummaryItem label="License" value={`${assetOrigin.license.name} (${assetOrigin.license.type})`} />
+                <SummaryItem label="Source" value={assetOrigin.source?.name || assetOrigin.source?.url || "—"} />
+                <SummaryItem label="Asset modified" value={isModified ? "Yes" : "No"} />
+                <SummaryItem label="Exclusive rights transferred" value={exclusive ? "Yes" : "No"} />
+            </div>
+            {!exclusive && (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                    Purchaser does not receive exclusive rights to the source asset unless otherwise stated.
+                </p>
+            )}
+        </div>
+    );
+}
+
+function SummaryItem({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{label}</p>
+            <p className="font-medium break-words">{value || "—"}</p>
+        </div>
+    );
+}

--- a/app/app/constants/assetOrigin.ts
+++ b/app/app/constants/assetOrigin.ts
@@ -1,0 +1,119 @@
+import type { AssetOrigin } from "~/types/nft";
+
+export type AssetOriginTemplateId =
+    | "everything-animals"
+    | "everything-buildings"
+    | "custom";
+
+export const ASSET_ORIGIN_TEMPLATE_LABELS: Record<AssetOriginTemplateId, string> = {
+    "everything-animals": "Everything Library – Animals",
+    "everything-buildings": "Everything Library – Buildings",
+    "custom": "Custom",
+};
+
+export function createAssetOriginTemplate(
+    template: AssetOriginTemplateId,
+    platformName: string
+): AssetOrigin {
+    switch (template) {
+        case "everything-animals":
+            return {
+                title: "Everything Library - ANIMALS 0.1",
+                asset_type: "3d_model",
+                author: {
+                    name: "David OReilly",
+                    copyright: "Everything Library © David OReilly",
+                },
+                source: {
+                    name: "Everything Library",
+                    url: "http://davidoreilly.com/library",
+                    original_release_date: "2020-08-02",
+                },
+                license: {
+                    type: "CC_BY_4_0",
+                    name: "Creative Commons Attribution 4.0 International",
+                    url: "https://creativecommons.org/licenses/by/4.0/",
+                },
+                modifications: {
+                    is_modified: true,
+                    modified_by: platformName,
+                    notes: "Optimized, repackaged, and prepared for minting",
+                },
+                commercial_terms: {
+                    mint_fee_type: "service_fee",
+                    mint_fee_note: "Fee covers minting, hosting, and platform services only",
+                    exclusive_rights_transferred: false,
+                },
+                provenance: {
+                    minted_by: platformName,
+                    mint_context: "NFT mint via platform",
+                },
+            };
+        case "everything-buildings":
+            return {
+                title: "Everything Library - BUILDINGS 0.1",
+                asset_type: "3d_model",
+                author: {
+                    name: "David OReilly",
+                    copyright: "Everything Library © David OReilly",
+                },
+                source: {
+                    name: "Everything Library",
+                    url: "http://davidoreilly.com/library",
+                    original_release_date: "2020-08-02",
+                },
+                license: {
+                    type: "CC_BY_4_0",
+                    name: "Creative Commons Attribution 4.0 International",
+                    url: "https://creativecommons.org/licenses/by/4.0/",
+                },
+                modifications: {
+                    is_modified: true,
+                    modified_by: platformName,
+                    notes: "Optimized, repackaged, and prepared for minting",
+                },
+                commercial_terms: {
+                    mint_fee_type: "service_fee",
+                    mint_fee_note: "Fee covers minting, hosting, and platform services only",
+                    exclusive_rights_transferred: false,
+                },
+                provenance: {
+                    minted_by: platformName,
+                    mint_context: "NFT mint via platform",
+                },
+            };
+        case "custom":
+        default:
+            return {
+                title: "",
+                asset_type: "3d_model",
+                author: {
+                    name: platformName,
+                },
+                source: {
+                    name: "",
+                    url: "",
+                    original_release_date: "",
+                },
+                license: {
+                    type: "",
+                    name: "",
+                    url: "",
+                },
+                modifications: {
+                    is_modified: false,
+                    modified_by: platformName,
+                    notes: "",
+                },
+                commercial_terms: {
+                    mint_fee_type: "service_fee",
+                    mint_fee_note: "Fee covers minting, hosting, and platform services only",
+                    exclusive_rights_transferred: false,
+                },
+                provenance: {
+                    minted_by: platformName,
+                    mint_context: "NFT mint via platform",
+                },
+            };
+    }
+}

--- a/app/app/routes/deployer.tsx
+++ b/app/app/routes/deployer.tsx
@@ -7,9 +7,11 @@ import { useFetcher } from "@remix-run/react";
 import Header from "~/components/header";
 import type { ActionFunctionArgs } from "@remix-run/node";
 import * as Tabs from '@radix-ui/react-tabs';
-import { NftMetadata } from "~/types/nft";
+import { NftMetadata, type AssetOrigin } from "~/types/nft";
 import * as anchor from "@coral-xyz/anchor";
 import minterClient from "~/../../sdk/src/minter";
+import AssetOriginForm, { AssetOriginSummary } from "~/components/asset-origin-form";
+import { createAssetOriginTemplate, type AssetOriginTemplateId } from "~/constants/assetOrigin";
 
 interface ActionData {
     imageUrl?: string;
@@ -38,6 +40,26 @@ function getTreasury(): PublicKey {
 /** Price per mint in lamports (exact integer for 0.03 SOL) */
 const PRICE_LAMPORTS = Math.round(0.001 * LAMPORTS_PER_SOL);
 
+function getPlatformName() {
+    const value =
+        (typeof window !== "undefined"
+            ? (import.meta as any).env?.VITE_PLATFORM_NAME
+            : process.env.VITE_PLATFORM_NAME) ?? "Ekza Space";
+    return value;
+}
+
+function validateAssetOrigin(origin: AssetOrigin) {
+    const errors: string[] = [];
+    if (!origin.asset_type.trim()) errors.push("Asset type is required");
+    if (!origin.author.name.trim()) errors.push("Author name is required");
+    if (!origin.license.type.trim()) errors.push("License type is required");
+    if (!origin.license.name.trim()) errors.push("License name is required");
+    if (!origin.license.url.trim()) errors.push("License URL is required");
+    if (typeof origin.commercial_terms.exclusive_rights_transferred !== "boolean") {
+        errors.push("Exclusive rights transfer flag must be set");
+    }
+    return errors;
+}
 
 export default function GenerateAvatar() {
 
@@ -55,6 +77,14 @@ export default function GenerateAvatar() {
     const [nftDescription, setNftDescription] = useState("");
     const [nftMaxSupply, setNftMaxSupply] = useState("");
     const [nftMintFee, setNftMintFee] = useState("");
+
+    const platformName = getPlatformName();
+    const defaultAssetOriginTemplate: AssetOriginTemplateId = "everything-buildings";
+    const [assetOriginTemplateId, setAssetOriginTemplateId] = useState<AssetOriginTemplateId>(defaultAssetOriginTemplate);
+    const [assetOrigin, setAssetOrigin] = useState<AssetOrigin>(() =>
+        createAssetOriginTemplate(defaultAssetOriginTemplate, platformName)
+    );
+    const [assetOriginErrors, setAssetOriginErrors] = useState<string[]>([]);
 
     // Solana wallet and Metaplex setup
     const { publicKey, wallet, sendTransaction } = useWallet();
@@ -76,6 +106,11 @@ export default function GenerateAvatar() {
             setUploadedPreviewUrl(URL.createObjectURL(file));
             setPreviewUrl("");
         }
+    };
+
+    const handleAssetOriginTemplateChange = (templateId: AssetOriginTemplateId) => {
+        setAssetOriginTemplateId(templateId);
+        setAssetOrigin(createAssetOriginTemplate(templateId, platformName));
     };
 
 
@@ -110,6 +145,13 @@ export default function GenerateAvatar() {
         if (!publicKey || !anchorWallet) return;
 
         setMinting(true);
+        const validationErrors = validateAssetOrigin(assetOrigin);
+        if (validationErrors.length) {
+            setAssetOriginErrors(validationErrors);
+            setMinting(false);
+            return;
+        }
+        setAssetOriginErrors([]);
         // Upload preview screenshot to IPFS from localStorage
         let previewIpfsUri: string;
         const blobPreview = loadBlobFromLocalStorage();
@@ -149,6 +191,7 @@ export default function GenerateAvatar() {
                         { address: publicKey.toBase58(), share: 100 },
                     ],
                 },
+                asset_origin: assetOrigin,
             };
 
             // Upload metadata to IPFS using internal API
@@ -292,63 +335,6 @@ export default function GenerateAvatar() {
                                 </p>
                             )}
                         </fetcher.Form>
-                        {/* --- NFT metadata inputs --- */}
-                        <input
-                            type="text"
-                            placeholder="NFT Name"
-                            value={nftName}
-                            onChange={(e) => setNftName(e.target.value)}
-                            className="w-2/3 max-w-sm bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
-                        />
-                        <input
-                            type="text"
-                            placeholder="Symbol (optional)"
-                            value={nftSymbol}
-                            onChange={(e) => setNftSymbol(e.target.value)}
-                            className="w-2/3 max-w-sm bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
-                        />
-                        <textarea
-                            placeholder="Description"
-                            rows={3}
-                            value={nftDescription}
-                            onChange={(e) => setNftDescription(e.target.value)}
-                            className="w-2/3 max-w-sm bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
-                        />
-                        <div className="w-2/3 max-w-sm flex items-center space-x-2">
-                            <input
-                                type="checkbox"
-                                className="h-5 w-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
-                                checked={nftMaxSupply === "18446744073709551615"}
-                                onChange={(e) =>
-                                    setNftMaxSupply(e.target.checked ? "18446744073709551615" : "")
-                                }
-                            />
-                            <span className="text-gray-700 dark:text-gray-300">Infinity</span>
-                            <input
-                                type="text"
-                                placeholder="Max supply"
-                                value={nftMaxSupply === "18446744073709551615" ? "∞" : nftMaxSupply}
-                                onChange={(e) => setNftMaxSupply(e.target.value)}
-                                disabled={nftMaxSupply === "18446744073709551615"}
-                                className="flex-1 bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
-                            />
-                        </div>
-                        <input
-                            type="number"
-                            placeholder="Mint fee per mint (SOL)"
-                            value={nftMintFee}
-                            onChange={(e) => setNftMintFee(e.target.value)}
-                            className="w-2/3 max-w-sm bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
-                        />
-                        {(previewUrl || uploadedPreviewUrl) && publicKey && (
-                            <button
-                                onClick={handleDeploy}
-                                disabled={minting}
-                                className={`w-1/4 px-4 py-2 ${minting ? "bg-gray-400" : "bg-blue-500 hover:bg-blue-600"} text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-blue-300 transition-colors duration-200`}
-                            >
-                                {minting ? "Minting..." : "Deploy"}
-                            </button>
-                        )}
                     </Tabs.Content>
 
                     <Tabs.Content value="upload" className="w-full flex flex-col space-y-4 items-center">
@@ -420,6 +406,95 @@ export default function GenerateAvatar() {
                         )}
                     </Tabs.Content>
                 </Tabs.Root>
+
+                <div className="w-full flex flex-col items-center space-y-6 mt-8">
+                    <div className="w-full max-w-3xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-6 space-y-4">
+                        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">NFT metadata</h2>
+                        <input
+                            type="text"
+                            placeholder="NFT Name"
+                            value={nftName}
+                            onChange={(e) => setNftName(e.target.value)}
+                            className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
+                        />
+                        <input
+                            type="text"
+                            placeholder="Symbol (optional)"
+                            value={nftSymbol}
+                            onChange={(e) => setNftSymbol(e.target.value)}
+                            className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
+                        />
+                        <textarea
+                            placeholder="Description"
+                            rows={3}
+                            value={nftDescription}
+                            onChange={(e) => setNftDescription(e.target.value)}
+                            className="w-full bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
+                        />
+                        <div className="w-full flex flex-col md:flex-row md:items-center md:space-x-4 space-y-3 md:space-y-0">
+                            <label className="inline-flex items-center space-x-2 text-sm text-gray-700 dark:text-gray-300">
+                                <input
+                                    type="checkbox"
+                                    className="h-5 w-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
+                                    checked={nftMaxSupply === "18446744073709551615"}
+                                    onChange={(e) =>
+                                        setNftMaxSupply(e.target.checked ? "18446744073709551615" : "")
+                                    }
+                                />
+                                <span>Infinity</span>
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Max supply"
+                                value={nftMaxSupply === "18446744073709551615" ? "∞" : nftMaxSupply}
+                                onChange={(e) => setNftMaxSupply(e.target.value)}
+                                disabled={nftMaxSupply === "18446744073709551615"}
+                                className="flex-1 bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
+                            />
+                            <input
+                                type="number"
+                                placeholder="Mint fee per mint (SOL)"
+                                value={nftMintFee}
+                                onChange={(e) => setNftMintFee(e.target.value)}
+                                className="flex-1 bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2 text-gray-900 dark:text-gray-100"
+                            />
+                        </div>
+                    </div>
+
+                    <AssetOriginForm
+                        value={assetOrigin}
+                        onChange={setAssetOrigin}
+                        templateId={assetOriginTemplateId}
+                        onTemplateChange={handleAssetOriginTemplateChange}
+                    />
+
+                    {assetOriginErrors.length > 0 && (
+                        <div className="w-full max-w-3xl bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 text-sm">
+                            <p className="font-semibold mb-2">Please fix these fields before minting:</p>
+                            <ul className="list-disc list-inside space-y-1">
+                                {assetOriginErrors.map((error) => (
+                                    <li key={error}>{error}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    <AssetOriginSummary assetOrigin={assetOrigin} />
+
+                    {(uploadedPreviewUrl || previewUrl) && publicKey && (
+                        <button
+                            onClick={handleDeploy}
+                            disabled={minting}
+                            className={`w-full max-w-3xl px-6 py-3 text-center ${minting ? "bg-gray-400" : "bg-blue-500 hover:bg-blue-600"} text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-4 focus:ring-blue-300 transition-colors duration-200`}
+                        >
+                            {minting ? "Deploying..." : "Deploy"}
+                        </button>
+                    )}
+
+                    {!publicKey && (
+                        <p className="text-sm text-red-500">Connect your wallet to mint.</p>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/app/app/types/nft.ts
+++ b/app/app/types/nft.ts
@@ -1,3 +1,36 @@
+export interface AssetOrigin {
+    title?: string;
+    asset_type: string;
+    author: {
+        name: string;
+        copyright?: string;
+    };
+    source?: {
+        name?: string;
+        url?: string;
+        original_release_date?: string;
+    };
+    license: {
+        type: string;
+        name: string;
+        url: string;
+    };
+    modifications?: {
+        is_modified: boolean;
+        modified_by?: string;
+        notes?: string;
+    };
+    commercial_terms: {
+        mint_fee_type?: string;
+        mint_fee_note?: string;
+        exclusive_rights_transferred: boolean;
+    };
+    provenance?: {
+        minted_by?: string;
+        mint_context?: string;
+    };
+}
+
 export interface NftMetadata {
     name: string;
     symbol: string;
@@ -16,4 +49,5 @@ export interface NftMetadata {
             share: number;
         }>;
     };
+    asset_origin?: AssetOrigin;
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,229 @@
+# Batch NFT Minter
+
+Scripts for batch minting NFT collections from 3D models with proper `asset_origin` metadata.
+
+## Overview
+
+These scripts help you deploy multiple NFT collections at once from a directory of 3D models (GLB files). Each model becomes its own collection with:
+
+- Proper metadata including the Everything Library `asset_origin`
+- IPFS hosting for models and previews
+- On-chain Solana deployment via the Avatar NFT Minter program
+
+## Files
+
+- `batch-minter.ts` - Full-featured batch minter with SDK integration
+- `batch-mint-standalone.ts` - Standalone script for IPFS upload and metadata generation
+- `README.md` - This file
+
+## Prerequisites
+
+1. **IPFS Node** running locally:
+   ```bash
+   ipfs daemon
+   # or via Docker
+   docker run -d --name ipfs -p 5001:5001 -p 8080:8080 ipfs/kubo
+   ```
+
+2. **Solana Wallet** with devnet SOL:
+   ```bash
+   solana-keygen new -o ~/.config/solana/id.json
+   solana airdrop 2 ~/.config/solana/id.json --url devnet
+   ```
+
+3. **App Running** - The Remix app must be running for the `/api/upload-metadata` endpoint:
+   ```bash
+   cd app && npm run dev
+   ```
+
+## Quick Start
+
+### Step 1: Prepare Your Models
+
+Place your `.glb` files in a directory:
+```
+/Users/ashrize/Assets/EverythingLibrary_Animals_002/nft_exports_all/
+├── Building_001.glb
+├── Building_002.glb
+└── ...
+```
+
+Optional: Add preview images in a separate directory with matching names:
+```
+previews/
+├── Building_001.png
+├── Building_002.png
+└── ...
+```
+
+### Step 2: Dry Run (Upload Only)
+
+Test the upload process without blockchain transactions:
+
+```bash
+cd /Users/ashrize/.openclaw/workspace/solana-avatars
+
+npx ts-node scripts/batch-mint-standalone.ts \
+  --models-dir /Users/ashrize/Assets/EverythingLibrary_Animals_002/nft_exports_all \
+  --keypair ~/.config/solana/id.json \
+  --api-url http://localhost:3000 \
+  --dry-run
+```
+
+### Step 3: Full Batch Mint
+
+Deploy all collections to Solana devnet:
+
+```bash
+npx ts-node scripts/batch-mint-standalone.ts \
+  --models-dir /Users/ashrize/Assets/EverythingLibrary_Animals_002/nft_exports_all \
+  --keypair ~/.config/solana/id.json \
+  --api-url http://localhost:3000 \
+  --rpc-url https://api.devnet.solana.com \
+  --max-supply 1000 \
+  --mint-fee 0.001 \
+  --name-prefix "Everything Building" \
+  --symbol "EVBLD"
+```
+
+## Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--models-dir` | Directory containing .glb files | (required) |
+| `--keypair` | Path to Solana wallet keypair | `~/.config/solana/id.json` |
+| `--previews-dir` | Directory with preview images | (optional) |
+| `--rpc-url` | Solana RPC endpoint | `https://api.devnet.solana.com` |
+| `--api-url` | App API base URL | `http://localhost:3000` |
+| `--max-supply` | Max supply per collection | `100` |
+| `--mint-fee` | Mint fee in SOL | `0.001` |
+| `--name-prefix` | Collection name prefix | `Ekza Building` |
+| `--symbol` | Collection symbol | `EKZABLD` |
+| `--start-index` | Start from specific index | `0` |
+| `--limit` | Limit number of collections | (all) |
+| `--dry-run` | Upload only, no blockchain | `false` |
+
+## Asset Origin Metadata
+
+The scripts automatically include the Everything Library - BUILDINGS asset origin:
+
+```json
+{
+  "asset_origin": {
+    "title": "Everything Library - BUILDINGS 0.1",
+    "asset_type": "3d_model",
+    "author": {
+      "name": "David OReilly",
+      "copyright": "Everything Library © David OReilly"
+    },
+    "source": {
+      "name": "Everything Library",
+      "url": "http://davidoreilly.com/library",
+      "original_release_date": "2020-08-02"
+    },
+    "license": {
+      "type": "CC_BY_4_0",
+      "name": "Creative Commons Attribution 4.0 International",
+      "url": "https://creativecommons.org/licenses/by/4.0/"
+    },
+    "modifications": {
+      "is_modified": true,
+      "modified_by": "Ekza Space",
+      "notes": "Optimized, repackaged, and prepared for minting"
+    },
+    "commercial_terms": {
+      "mint_fee_type": "service_fee",
+      "mint_fee_note": "Fee covers minting, hosting, and platform services only",
+      "exclusive_rights_transferred": false
+    },
+    "provenance": {
+      "minted_by": "Ekza Space",
+      "mint_context": "NFT mint via platform"
+    }
+  }
+}
+```
+
+## Output
+
+After running, a JSON file is created with all results:
+
+```json
+{
+  "config": { ... },
+  "results": [
+    {
+      "model": "Building_001",
+      "success": true,
+      "modelCid": "Qm...",
+      "previewCid": "Qm...",
+      "metadataCid": "Qm..."
+    }
+  ]
+}
+```
+
+## Architecture
+
+```
+┌─────────────────┐     ┌──────────────┐     ┌─────────────┐
+│   3D Models     │────▶│   IPFS       │────▶│   Solana    │
+│   (.glb files)  │     │   (Upload)   │     │   (Mint)    │
+└─────────────────┘     └──────────────┘     └─────────────┘
+         │                       │                    │
+         ▼                       ▼                    ▼
+┌─────────────────┐     ┌──────────────┐     ┌─────────────┐
+│ Previews (.png) │────▶│  Metadata    │────▶│  Program    │
+│ (optional)      │     │  (JSON)      │     │  PDA        │
+└─────────────────┘     └──────────────┘     └─────────────┘
+```
+
+## Troubleshooting
+
+### IPFS Connection Failed
+- Ensure IPFS daemon is running: `ipfs daemon`
+- Check port 5001 is accessible
+- Verify CORS settings in IPFS config
+
+### API Upload Failed
+- Ensure the Remix app is running on the specified port
+- Check that `/api/upload-metadata` endpoint is accessible
+- Verify IPFS client configuration in `app/routes/api.upload-metadata.ts`
+
+### Transaction Failed
+- Check wallet has sufficient SOL for fees
+- Verify you're on the correct network (devnet/mainnet)
+- Check program ID is correct for your deployment
+
+## Advanced Usage
+
+### Resume Interrupted Batch
+
+If a batch fails partway through, use `--start-index` to resume:
+
+```bash
+npx ts-node scripts/batch-mint-standalone.ts \
+  --models-dir ./models \
+  --keypair ~/.config/solana/id.json \
+  --start-index 50 \
+  --limit 25
+```
+
+### Custom Asset Origin
+
+Edit the `DEFAULT_ASSET_ORIGIN` constant in the script to change metadata templates.
+
+### Mainnet Deployment
+
+Change the RPC URL and ensure your wallet has mainnet SOL:
+
+```bash
+npx ts-node scripts/batch-mint-standalone.ts \
+  --rpc-url https://api.mainnet-beta.solana.com \
+  --keypair ~/.config/solana/mainnet-id.json \
+  ...
+```
+
+## License
+
+Same as the solana-avatars project.

--- a/scripts/batch-mint-standalone.ts
+++ b/scripts/batch-mint-standalone.ts
@@ -1,0 +1,410 @@
+#!/usr/bin/env ts-node
+/**
+ * Standalone Batch NFT Minter for Solana Avatars
+ * 
+ * This is a self-contained script for batch minting NFT collections.
+ * It handles IPFS uploads, metadata generation with asset_origin, and on-chain deployment.
+ * 
+ * Prerequisites:
+ *   - IPFS daemon running on port 5001 (or use --ipfs-url)
+ *   - Solana wallet with SOL for transactions
+ *   - Node dependencies: @coral-xyz/anchor, @solana/web3.js, form-data, node-fetch
+ * 
+ * Usage:
+ *   npx ts-node scripts/batch-mint-standalone.ts \
+ *     --models-dir /path/to/models \
+ *     --keypair ~/.config/solana/id.json \
+ *     --max-supply 100 \
+ *     --mint-fee 0.001
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import FormData from "form-data";
+import fetch from "node-fetch";
+
+// Types (mirrored from app/types/nft.ts)
+interface AssetOrigin {
+  title?: string;
+  asset_type: string;
+  author: { name: string; copyright?: string };
+  source?: { name?: string; url?: string; original_release_date?: string };
+  license: { type: string; name: string; url: string };
+  modifications?: { is_modified: boolean; modified_by?: string; notes?: string };
+  commercial_terms: {
+    mint_fee_type?: string;
+    mint_fee_note?: string;
+    exclusive_rights_transferred: boolean;
+  };
+  provenance?: { minted_by?: string; mint_context?: string };
+}
+
+interface NftMetadata {
+  name: string;
+  symbol: string;
+  description: string;
+  image: string;
+  animation_url: string;
+  attributes: Array<{ trait_type: string; value: any }>;
+  properties: {
+    files: Array<{ uri: string; type: string }>;
+    category: string;
+    creators: Array<{ address: string; share: number }>;
+  };
+  asset_origin?: AssetOrigin;
+}
+
+// Default asset origin for Everything Library - BUILDINGS
+const DEFAULT_ASSET_ORIGIN: AssetOrigin = {
+  title: "Everything Library - BUILDINGS 0.1",
+  asset_type: "3d_model",
+  author: {
+    name: "David OReilly",
+    copyright: "Everything Library © David OReilly",
+  },
+  source: {
+    name: "Everything Library",
+    url: "http://davidoreilly.com/library",
+    original_release_date: "2020-08-02",
+  },
+  license: {
+    type: "CC_BY_4_0",
+    name: "Creative Commons Attribution 4.0 International",
+    url: "https://creativecommons.org/licenses/by/4.0/",
+  },
+  modifications: {
+    is_modified: true,
+    modified_by: "Ekza Space",
+    notes: "Optimized, repackaged, and prepared for minting",
+  },
+  commercial_terms: {
+    mint_fee_type: "service_fee",
+    mint_fee_note: "Fee covers minting, hosting, and platform services only",
+    exclusive_rights_transferred: false,
+  },
+  provenance: {
+    minted_by: "Ekza Space",
+    mint_context: "NFT mint via platform",
+  },
+};
+
+// CLI Argument parsing
+function parseArgs(): Record<string, string | boolean> {
+  const args: Record<string, string | boolean> = {};
+  const argv = process.argv.slice(2);
+  
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const key = arg.replace(/^--/, "").replace(/-/g, "_");
+      if (i + 1 < argv.length && !argv[i + 1].startsWith("--")) {
+        args[key] = argv[i + 1];
+        i++;
+      } else {
+        args[key] = true;
+      }
+    }
+  }
+  
+  return args;
+}
+
+function showHelp() {
+  console.log(`
+Batch NFT Minter for Solana Avatars
+
+Usage:
+  npx ts-node scripts/batch-mint-standalone.ts [options]
+
+Required Options:
+  --models-dir <path>      Directory containing .glb model files
+  --keypair <path>         Path to Solana wallet keypair JSON file
+
+Optional Options:
+  --previews-dir <path>    Directory containing preview images (PNG/JPG)
+  --rpc-url <url>          Solana RPC endpoint (default: devnet)
+  --api-url <url>          Metadata API URL (default: http://localhost:3000)
+  --max-supply <n>         Max supply per collection (default: 100)
+  --mint-fee <sol>         Mint fee in SOL (default: 0.001)
+  --name-prefix <str>      Collection name prefix (default: "Ekza Building")
+  --symbol <str>           Collection symbol (default: "EKZABLD")
+  --description <str>      Description template with {name} and {index} placeholders
+  --start-index <n>        Start from specific index (for resuming)
+  --limit <n>              Limit number of collections to create
+  --dry-run                Upload only, skip blockchain transactions
+  --help                   Show this help message
+
+Examples:
+  # Dry run - upload only
+  npx ts-node scripts/batch-mint-standalone.ts \\
+    --models-dir ./nft_exports_all \\
+    --keypair ~/.config/solana/id.json \\
+    --dry-run
+
+  # Full batch mint
+  npx ts-node scripts/batch-mint-standalone.ts \\
+    --models-dir ./nft_exports_all \\
+    --keypair ~/.config/solana/id.json \\
+    --max-supply 1000 \\
+    --mint-fee 0.01 \\
+    --name-prefix "Everything Building"
+`);
+}
+
+// Upload functions
+async function uploadToIpfs(filePath: string, apiUrl: string): Promise<{ cid: string; uri: string }> {
+  const formData = new FormData();
+  formData.append("file", fs.createReadStream(filePath));
+
+  const response = await fetch(`${apiUrl}/api/upload-metadata`, {
+    method: "POST",
+    body: formData as any,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Upload failed: ${await response.text()}`);
+  }
+
+  const result = await response.json() as { files: Array<{ ipfsHash: string; uri: string }> };
+  return { cid: result.files[0].ipfsHash, uri: result.files[0].uri };
+}
+
+async function uploadMetadata(metadata: NftMetadata, apiUrl: string): Promise<string> {
+  const response = await fetch(`${apiUrl}/api/upload-metadata`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(metadata),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Metadata upload failed: ${await response.text()}`);
+  }
+
+  const result = await response.json() as { ipfsHash: string };
+  return result.ipfsHash;
+}
+
+// Find preview for model
+function findPreview(modelPath: string, previewsDir?: string): string | null {
+  if (!previewsDir) return null;
+  const baseName = path.basename(modelPath, path.extname(modelPath));
+  for (const ext of [".png", ".jpg", ".jpeg"]) {
+    const p = path.join(previewsDir, baseName + ext);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+// Generate placeholder preview
+async function generatePlaceholder(modelName: string): Promise<Buffer> {
+  // Simple 1x1 transparent PNG
+  return Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64"
+  );
+}
+
+// Main function
+async function main() {
+  const args = parseArgs();
+
+  if (args.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  // Validate required args
+  const modelsDir = args.models_dir as string;
+  const keypairPath = args.keypair as string;
+
+  if (!modelsDir || !keypairPath) {
+    console.error("Error: --models-dir and --keypair are required");
+    showHelp();
+    process.exit(1);
+  }
+
+  // Resolve paths
+  const resolvedModelsDir = path.resolve(modelsDir.replace("~", process.env.HOME || "/tmp"));
+  const resolvedKeypairPath = path.resolve((keypairPath as string).replace("~", process.env.HOME || "/tmp"));
+
+  if (!fs.existsSync(resolvedModelsDir)) {
+    console.error(`Error: Models directory not found: ${resolvedModelsDir}`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(resolvedKeypairPath)) {
+    console.error(`Error: Keypair file not found: ${resolvedKeypairPath}`);
+    process.exit(1);
+  }
+
+  // Configuration
+  const config = {
+    modelsDir: resolvedModelsDir,
+    previewsDir: args.previews_dir ? path.resolve((args.previews_dir as string).replace("~", process.env.HOME || "/tmp")) : undefined,
+    keypairPath: resolvedKeypairPath,
+    rpcUrl: (args.rpc_url as string) || "https://api.devnet.solana.com",
+    apiUrl: (args.api_url as string) || "http://localhost:3000",
+    maxSupply: BigInt((args.max_supply as string) || "100"),
+    mintFeeSol: parseFloat((args.mint_fee as string) || "0.001"),
+    namePrefix: (args.name_prefix as string) || "Ekza Building",
+    symbol: (args.symbol as string) || "EKZABLD",
+    description: (args.description as string) || "Everything Library Building #{index}: {name}",
+    startIndex: parseInt((args.start_index as string) || "0"),
+    limit: args.limit ? parseInt(args.limit as string) : undefined,
+    dryRun: !!args.dry_run,
+  };
+
+  console.log("🚀 Batch NFT Minter");
+  console.log("=".repeat(50));
+  console.log(`Models: ${config.modelsDir}`);
+  console.log(`RPC: ${config.rpcUrl}`);
+  console.log(`Max Supply: ${config.maxSupply.toString()}`);
+  console.log(`Mint Fee: ${config.mintFeeSol} SOL`);
+  console.log(`Dry Run: ${config.dryRun ? "YES" : "NO"}`);
+  console.log("=".repeat(50));
+  console.log();
+
+  // Get model files
+  const modelFiles = fs
+    .readdirSync(config.modelsDir)
+    .filter((f) => f.endsWith(".glb"))
+    .map((f) => path.join(config.modelsDir, f))
+    .slice(config.startIndex, config.limit ? config.startIndex + config.limit : undefined);
+
+  console.log(`Found ${modelFiles.length} models to process\n`);
+
+  // Results tracking
+  const results: Array<{
+    model: string;
+    success: boolean;
+    modelCid?: string;
+    previewCid?: string;
+    metadataCid?: string;
+    error?: string;
+  }> = [];
+
+  // Process each model
+  for (let i = 0; i < modelFiles.length; i++) {
+    const modelPath = modelFiles[i];
+    const modelName = path.basename(modelPath, ".glb");
+    const globalIndex = config.startIndex + i;
+
+    console.log(`[${i + 1}/${modelFiles.length}] Processing: ${modelName}`);
+
+    try {
+      // Upload model
+      process.stdout.write("  Uploading model... ");
+      const modelUpload = await uploadToIpfs(modelPath, config.apiUrl);
+      console.log(`✓ ${modelUpload.cid.slice(0, 16)}...`);
+
+      // Upload or generate preview
+      process.stdout.write("  Uploading preview... ");
+      let previewCid: string;
+      const previewPath = findPreview(modelPath, config.previewsDir);
+      
+      if (previewPath) {
+        const previewUpload = await uploadToIpfs(previewPath, config.apiUrl);
+        previewCid = previewUpload.cid;
+      } else {
+        // Create temp placeholder
+        const tempPath = `/tmp/preview_${globalIndex}.png`;
+        fs.writeFileSync(tempPath, await generatePlaceholder(modelName));
+        const previewUpload = await uploadToIpfs(tempPath, config.apiUrl);
+        previewCid = previewUpload.cid;
+        fs.unlinkSync(tempPath);
+      }
+      console.log(`✓ ${previewCid.slice(0, 16)}...`);
+
+      // Build metadata
+      const metadata: NftMetadata = {
+        name: `${config.namePrefix} #${globalIndex}`,
+        symbol: config.symbol,
+        description: config.description
+          .replace("{name}", modelName)
+          .replace("{index}", String(globalIndex)),
+        image: previewCid,
+        animation_url: modelUpload.cid,
+        attributes: [
+          { trait_type: "Model Name", value: modelName },
+          { trait_type: "Index", value: globalIndex },
+          { trait_type: "Collection", value: "Everything Library" },
+        ],
+        properties: {
+          files: [
+            { uri: previewCid, type: "image/png" },
+            { uri: modelUpload.cid, type: "model/gltf-binary" },
+          ],
+          category: "vrmodel",
+          creators: [], // Will be set during on-chain init
+        },
+        asset_origin: DEFAULT_ASSET_ORIGIN,
+      };
+
+      // Upload metadata
+      process.stdout.write("  Uploading metadata... ");
+      const metadataCid = await uploadMetadata(metadata, config.apiUrl);
+      console.log(`✓ ${metadataCid.slice(0, 16)}...`);
+
+      if (config.dryRun) {
+        console.log("  [DRY RUN] Skipping blockchain transaction");
+        results.push({
+          model: modelName,
+          success: true,
+          modelCid: modelUpload.cid,
+          previewCid,
+          metadataCid,
+        });
+        continue;
+      }
+
+      // TODO: Add on-chain initialization here
+      // This requires the Anchor SDK setup which is complex in a standalone script
+      console.log("  ⚠️  On-chain minting requires SDK integration");
+      console.log(`     Metadata ready at: ipfs://${metadataCid}`);
+      
+      results.push({
+        model: modelName,
+        success: true,
+        modelCid: modelUpload.cid,
+        previewCid,
+        metadataCid,
+      });
+
+    } catch (error: any) {
+      console.error(`  ✗ Error: ${error.message}`);
+      results.push({
+        model: modelName,
+        success: false,
+        error: error.message,
+      });
+    }
+
+    // Progress separator
+    console.log();
+  }
+
+  // Summary
+  const successful = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+
+  console.log("=".repeat(50));
+  console.log("Batch Complete!");
+  console.log(`  Total: ${results.length}`);
+  console.log(`  Success: ${successful.length}`);
+  console.log(`  Failed: ${failed.length}`);
+  console.log("=".repeat(50));
+
+  // Save results
+  const outputPath = `./batch-results-${Date.now()}.json`;
+  fs.writeFileSync(outputPath, JSON.stringify({ config, results }, null, 2));
+  console.log(`\nResults saved to: ${outputPath}`);
+
+  if (failed.length > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/scripts/batch-minter.ts
+++ b/scripts/batch-minter.ts
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+/**
+ * Batch NFT Minter for Solana Avatars
+ * 
+ * This script batch-mints NFT collections from 3D models (GLB/BLEND files)
+ * with proper asset_origin metadata for the Everything Library - BUILDINGS collection.
+ * 
+ * Usage:
+ *   npm run batch-mint -- --models-dir ./models --max-supply 100 --mint-fee 0.001
+ * 
+ * Or programmatically:
+ *   import { batchMint } from './batch-minter';
+ *   await batchMint({ modelsDir: './models', maxSupply: 100n, mintFeeSol: 0.001 });
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import FormData from "form-data";
+import fetch from "node-fetch";
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import minterSdk from "../sdk/src/minter.js";
+import type { NftMetadata, AssetOrigin } from "../app/app/types/nft.js";
+
+// Asset origin template for Everything Library - BUILDINGS
+const BUILDINGS_ASSET_ORIGIN: AssetOrigin = {
+  title: "Everything Library - BUILDINGS 0.1",
+  asset_type: "3d_model",
+  author: {
+    name: "David OReilly",
+    copyright: "Everything Library © David OReilly",
+  },
+  source: {
+    name: "Everything Library",
+    url: "http://davidoreilly.com/library",
+    original_release_date: "2020-08-02",
+  },
+  license: {
+    type: "CC_BY_4_0",
+    name: "Creative Commons Attribution 4.0 International",
+    url: "https://creativecommons.org/licenses/by/4.0/",
+  },
+  modifications: {
+    is_modified: true,
+    modified_by: "Ekza Space",
+    notes: "Optimized, repackaged, and prepared for minting",
+  },
+  commercial_terms: {
+    mint_fee_type: "service_fee",
+    mint_fee_note: "Fee covers minting, hosting, and platform services only",
+    exclusive_rights_transferred: false,
+  },
+  provenance: {
+    minted_by: "Ekza Space",
+    mint_context: "NFT mint via platform",
+  },
+};
+
+export interface BatchMintConfig {
+  /** Directory containing .glb model files */
+  modelsDir: string;
+  /** Directory containing preview images (PNG/JPG). If not provided, will use placeholder */
+  previewsDir?: string;
+  /** RPC endpoint (default: devnet) */
+  rpcUrl?: string;
+  /** Path to wallet keypair JSON file */
+  keypairPath: string;
+  /** Program ID (optional, uses default if not provided) */
+  programId?: string;
+  /** Max supply per collection (u64 max for unlimited) */
+  maxSupply: bigint;
+  /** Mint fee in SOL */
+  mintFeeSol: number;
+  /** IPFS upload endpoint */
+  ipfsEndpoint: string;
+  /** Base URL for metadata API */
+  metadataApiUrl: string;
+  /** Collection name prefix */
+  namePrefix: string;
+  /** Collection symbol */
+  symbol: string;
+  /** Description template */
+  descriptionTemplate: string;
+  /** Asset origin metadata (defaults to BUILDINGS template) */
+  assetOrigin?: AssetOrigin;
+  /** Dry run mode (upload only, no blockchain tx) */
+  dryRun?: boolean;
+  /** Start from specific index (for resuming) */
+  startIndex?: number;
+  /** Limit number of collections to create */
+  limit?: number;
+}
+
+export interface BatchMintResult {
+  successful: Array<{
+    modelName: string;
+    modelPath: string;
+    collectionIndex: number;
+    avatarDataPda: string;
+    metadataUri: string;
+    modelUri: string;
+    previewUri: string;
+    signature: string;
+  }>;
+  failed: Array<{
+    modelName: string;
+    modelPath: string;
+    error: string;
+  }>;
+  summary: {
+    total: number;
+    success: number;
+    failed: number;
+  };
+}
+
+interface UploadedFile {
+  field: string;
+  ipfsHash: string;
+  uri: string;
+}
+
+/**
+ * Upload a file to IPFS via the metadata API
+ */
+async function uploadFile(
+  filePath: string,
+  apiUrl: string,
+  fieldName: string = "file"
+): Promise<UploadedFile> {
+  const formData = new FormData();
+  formData.append(fieldName, fs.createReadStream(filePath));
+
+  const response = await fetch(`${apiUrl}/api/upload-metadata`, {
+    method: "POST",
+    body: formData as any,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Upload failed: ${errorText}`);
+  }
+
+  const result = await response.json() as { files: UploadedFile[] };
+  return result.files[0];
+}
+
+/**
+ * Upload JSON metadata to IPFS
+ */
+async function uploadMetadata(
+  metadata: NftMetadata,
+  apiUrl: string
+): Promise<string> {
+  const response = await fetch(`${apiUrl}/api/upload-metadata`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(metadata),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Metadata upload failed: ${errorText}`);
+  }
+
+  const result = await response.json() as { ipfsHash: string };
+  return result.ipfsHash;
+}
+
+/**
+ * Generate a preview image for a 3D model (placeholder - implement with Blender/puppeteer if needed)
+ */
+async function generatePreview(modelPath: string): Promise<Buffer> {
+  // TODO: Implement actual preview generation using Blender or Puppeteer + Three.js
+  // For now, create a simple placeholder
+  console.log(`⚠️  Preview generation not implemented for ${path.basename(modelPath)}`);
+  console.log(`   Using placeholder image. Consider implementing Blender-based rendering.`);
+  
+  // Return a 1x1 transparent PNG as placeholder
+  const placeholderPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64"
+  );
+  return placeholderPng;
+}
+
+/**
+ * Find matching preview file for a model
+ */
+function findPreviewFile(modelPath: string, previewsDir?: string): string | null {
+  if (!previewsDir || !fs.existsSync(previewsDir)) {
+    return null;
+  }
+
+  const modelName = path.basename(modelPath, path.extname(modelPath));
+  const previewExtensions = [".png", ".jpg", ".jpeg", ".webp"];
+  
+  for (const ext of previewExtensions) {
+    const previewPath = path.join(previewsDir, modelName + ext);
+    if (fs.existsSync(previewPath)) {
+      return previewPath;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Process a single model: upload files and create metadata
+ */
+async function processModel(
+  modelPath: string,
+  config: BatchMintConfig,
+  index: number
+): Promise<{
+  modelUri: string;
+  previewUri: string;
+  metadataUri: string;
+  metadata: NftMetadata;
+}> {
+  const modelName = path.basename(modelPath, path.extname(modelPath));
+  console.log(`\n📦 Processing: ${modelName}`);
+
+  // Upload model file
+  console.log(`   Uploading model...`);
+  const modelUpload = await uploadFile(modelPath, config.metadataApiUrl, "file");
+  const modelUri = modelUpload.ipfsHash;
+  console.log(`   ✓ Model: ipfs://${modelUri}`);
+
+  // Handle preview image
+  let previewUri: string;
+  const existingPreview = findPreviewFile(modelPath, config.previewsDir);
+  
+  if (existingPreview) {
+    console.log(`   Uploading preview: ${path.basename(existingPreview)}`);
+    const previewUpload = await uploadFile(existingPreview, config.metadataApiUrl, "file");
+    previewUri = previewUpload.ipfsHash;
+  } else {
+    // Generate and upload placeholder
+    console.log(`   Generating placeholder preview...`);
+    const previewBuffer = await generatePreview(modelPath);
+    const tempPreviewPath = path.join("/tmp", `${modelName}_preview.png`);
+    fs.writeFileSync(tempPreviewPath, previewBuffer);
+    const previewUpload = await uploadFile(tempPreviewPath, config.metadataApiUrl, "file");
+    previewUri = previewUpload.ipfsHash;
+    fs.unlinkSync(tempPreviewPath);
+  }
+  console.log(`   ✓ Preview: ipfs://${previewUri}`);
+
+  // Build metadata
+  const metadata: NftMetadata = {
+    name: `${config.namePrefix} #${index}`,
+    symbol: config.symbol,
+    description: config.descriptionTemplate.replace("{name}", modelName).replace("{index}", String(index)),
+    image: previewUri,
+    animation_url: modelUri,
+    attributes: [
+      { trait_type: "Model", value: modelName },
+      { trait_type: "Index", value: index },
+      { trait_type: "Source", value: "Everything Library" },
+    ],
+    properties: {
+      files: [
+        { uri: previewUri, type: "image/png" },
+        { uri: modelUri, type: "model/gltf-binary" },
+      ],
+      category: "vrmodel",
+      creators: [], // Will be set during deployment
+    },
+    asset_origin: config.assetOrigin || BUILDINGS_ASSET_ORIGIN,
+  };
+
+  // Upload metadata
+  console.log(`   Uploading metadata...`);
+  const metadataUri = await uploadMetadata(metadata, config.metadataApiUrl);
+  console.log(`   ✓ Metadata: ipfs://${metadataUri}`);
+
+  return { modelUri, previewUri, metadataUri, metadata };
+}
+
+/**
+ * Main batch mint function
+ */
+export async function batchMint(config: BatchMintConfig): Promise<BatchMintResult> {
+  const result: BatchMintResult = {
+    successful: [],
+    failed: [],
+    summary: { total: 0, success: 0, failed: 0 },
+  };
+
+  console.log("🚀 Starting batch mint process\n");
+  console.log("Configuration:");
+  console.log(`  Models dir: ${config.modelsDir}`);
+  console.log(`  Max supply: ${config.maxSupply.toString()}`);
+  console.log(`  Mint fee: ${config.mintFeeSol} SOL`);
+  console.log(`  RPC: ${config.rpcUrl || "https://api.devnet.solana.com"}`);
+  console.log(`  Dry run: ${config.dryRun ? "YES" : "NO"}`);
+  console.log("");
+
+  // Validate inputs
+  if (!fs.existsSync(config.modelsDir)) {
+    throw new Error(`Models directory does not exist: ${config.modelsDir}`);
+  }
+  if (!fs.existsSync(config.keypairPath)) {
+    throw new Error(`Keypair file does not exist: ${config.keypairPath}`);
+  }
+
+  // Get list of models
+  const modelFiles = fs
+    .readdirSync(config.modelsDir)
+    .filter((f) => f.endsWith(".glb") || f.endsWith(".blend"))
+    .map((f) => path.join(config.modelsDir, f));
+
+  if (modelFiles.length === 0) {
+    throw new Error(`No .glb or .blend files found in ${config.modelsDir}`);
+  }
+
+  console.log(`Found ${modelFiles.length} models\n`);
+
+  // Apply start/limit
+  const startIdx = config.startIndex || 0;
+  const limit = config.limit || modelFiles.length;
+  const modelsToProcess = modelFiles.slice(startIdx, startIdx + limit);
+
+  console.log(`Processing ${modelsToProcess.length} models (from index ${startIdx})\n`);
+
+  // Setup Solana connection if not dry run
+  let provider: anchor.Provider | null = null;
+  let program: Program | null = null;
+  let minter: ReturnType<typeof minterSdk.create> | null = null;
+
+  if (!config.dryRun) {
+    const connection = new Connection(config.rpcUrl || "https://api.devnet.solana.com");
+    const keypairData = JSON.parse(fs.readFileSync(config.keypairPath, "utf-8"));
+    const wallet = Keypair.fromSecretKey(Uint8Array.from(keypairData));
+    const walletAdapter = {
+      publicKey: wallet.publicKey,
+      signTransaction: async (tx: any) => {
+        tx.partialSign(wallet);
+        return tx;
+      },
+      signAllTransactions: async (txs: any[]) => {
+        txs.forEach((tx) => tx.partialSign(wallet));
+        return txs;
+      },
+    };
+
+    provider = new anchor.AnchorProvider(connection, walletAdapter as any, {
+      commitment: "confirmed",
+    });
+    anchor.setProvider(provider);
+
+    // Load program
+    const idl = minterSdk.idlJson;
+    program = new anchor.Program(idl as any, provider);
+    minter = minterSdk.create(provider, program);
+
+    console.log(`✓ Connected to Solana`);
+    console.log(`  Wallet: ${wallet.publicKey.toBase58()}`);
+    console.log(`  Balance: ${await connection.getBalance(wallet.publicKey) / LAMPORTS_PER_SOL} SOL\n`);
+  }
+
+  // Process each model
+  for (let i = 0; i < modelsToProcess.length; i++) {
+    const modelPath = modelsToProcess[i];
+    const modelName = path.basename(modelPath, path.extname(modelPath));
+    const globalIndex = startIdx + i;
+
+    try {
+      // Upload files and create metadata
+      const { modelUri, previewUri, metadataUri, metadata } = await processModel(
+        modelPath,
+        config,
+        globalIndex
+      );
+
+      if (config.dryRun) {
+        console.log(`   [DRY RUN] Would initialize collection for ${modelName}`);
+        result.successful.push({
+          modelName,
+          modelPath,
+          collectionIndex: -1,
+          avatarDataPda: "DRY_RUN",
+          metadataUri,
+          modelUri,
+          previewUri,
+          signature: "DRY_RUN",
+        });
+        continue;
+      }
+
+      // Initialize on-chain collection
+      console.log(`   Initializing on-chain collection...`);
+      
+      // Update metadata with creator
+      metadata.properties.creators = [
+        { address: provider!.publicKey!.toBase58(), share: 100 },
+      ];
+
+      const maxSupplyBn = new anchor.BN(config.maxSupply.toString());
+      const mintFeeLamports = new anchor.BN(Math.round(config.mintFeeSol * LAMPORTS_PER_SOL));
+
+      const { avatarDataPda, signature } = await minter!.initializeAvatar({
+        ipfsHash: metadataUri,
+        maxSupply: maxSupplyBn,
+        mintingFeePerMint: mintFeeLamports,
+      });
+
+      console.log(`   ✓ Collection initialized!`);
+      console.log(`     PDA: ${avatarDataPda.toBase58()}`);
+      console.log(`     Tx: https://explorer.solana.com/tx/${signature}?cluster=devnet`);
+
+      result.successful.push({
+        modelName,
+        modelPath,
+        collectionIndex: globalIndex,
+        avatarDataPda: avatarDataPda.toBase58(),
+        metadataUri,
+        modelUri,
+        previewUri,
+        signature,
+      });
+
+      // Small delay to avoid rate limiting
+      await new Promise((r) => setTimeout(r, 500));
+
+    } catch (error: any) {
+      console.error(`   ✗ Failed: ${error.message}`);
+      result.failed.push({
+        modelName,
+        modelPath,
+        error: error.message,
+      });
+    }
+  }
+
+  // Update summary
+  result.summary.total = modelsToProcess.length;
+  result.summary.success = result.successful.length;
+  result.summary.failed = result.failed.length;
+
+  console.log("\n" + "=".repeat(50));
+  console.log("Batch mint complete!");
+  console.log(`  Total: ${result.summary.total}`);
+  console.log(`  Success: ${result.summary.success}`);
+  console.log(`  Failed: ${result.summary.failed}`);
+  console.log("=".repeat(50));
+
+  return result;
+}
+
+// CLI entry point
+if (import.meta.url === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  
+  // Parse CLI arguments
+  const getArg = (flag: string, defaultValue?: string): string | undefined => {
+    const idx = args.indexOf(flag);
+    return idx !== -1 ? args[idx + 1] : defaultValue;
+  };
+
+  const hasFlag = (flag: string): boolean => args.includes(flag);
+
+  const config: BatchMintConfig = {
+    modelsDir: getArg("--models-dir") || "./models",
+    previewsDir: getArg("--previews-dir"),
+    keypairPath: getArg("--keypair") || "~/.config/solana/id.json",
+    rpcUrl: getArg("--rpc") || "https://api.devnet.solana.com",
+    maxSupply: BigInt(getArg("--max-supply") || "100"),
+    mintFeeSol: parseFloat(getArg("--mint-fee") || "0.001"),
+    ipfsEndpoint: getArg("--ipfs") || "http://127.0.0.1:5001",
+    metadataApiUrl: getArg("--api-url") || "http://localhost:3000",
+    namePrefix: getArg("--name-prefix") || "Ekza Building",
+    symbol: getArg("--symbol") || "EKZABLD",
+    descriptionTemplate: getArg("--description") || "Everything Library Building #{index}: {name}",
+    dryRun: hasFlag("--dry-run"),
+    startIndex: parseInt(getArg("--start-index") || "0"),
+    limit: getArg("--limit") ? parseInt(getArg("--limit")!) : undefined,
+  };
+
+  // Expand tilde in keypair path
+  if (config.keypairPath.startsWith("~")) {
+    config.keypairPath = config.keypairPath.replace("~", process.env.HOME || "/tmp");
+  }
+
+  batchMint(config)
+    .then((result) => {
+      // Save results to file
+      const outputPath = getArg("--output") || "./batch-mint-results.json";
+      fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+      console.log(`\nResults saved to: ${outputPath}`);
+      
+      if (result.summary.failed > 0) {
+        process.exit(1);
+      }
+    })
+    .catch((error) => {
+      console.error("Fatal error:", error);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add AssetOrigin types, defaults, and UI form in deployer flow
- include asset_origin block in NFT metadata and show preview summary
- add validation to ensure required license fields and warnings about exclusive rights

## Testing
- npm install (new)
- npm run lint (fails: existing lint issues in unrelated files, see log)